### PR TITLE
Remove entry-point call and add chalice call test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,8 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
-  entry_points:
-    - chalice = pytest_chalice.plugin:main_entry_point
 
 requirements:
   host:
@@ -30,6 +28,8 @@ requirements:
 test:
   imports:
     - pytest_chalice
+  commands:
+    - chalice --help
 
 about:
   home: "https://github.com/studio3104/pytest-chalice"


### PR DESCRIPTION
Close #1

Please see that upstream [setup.py](https://github.com/studio3104/pytest-chalice/blob/52fe56e0cf7a7be4b74a6422133d751f66c1ce30/setup.py#L54-L59) does not include any console entry-points: